### PR TITLE
Give push workflow write permission

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: write
+
 jobs:
   deploy_doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently erroring out with:

```txt
INFO    -  Copying '/home/runner/work/phd_topic_ideas/phd_topic_ideas/site' to 'gh-pages' branch and pushing to GitHub.
remote: Permission to karl-johan-grahn/phd_topic_ideas.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/karl-johan-grahn/phd_topic_ideas/': The requested URL returned error: 403
```